### PR TITLE
Add ImageWithIndicator

### DIFF
--- a/src/components/plants/PlantListItem.tsx
+++ b/src/components/plants/PlantListItem.tsx
@@ -6,10 +6,10 @@ import {
   Dimensions,
   TouchableOpacity,
 } from "react-native";
-import FastImage from "react-native-fast-image";
 
 import { NavigationProps } from "../Router";
 import { Plant } from "../../api/Types";
+import ImageWithIndicator from "../shared/ImageWithIndicator";
 
 interface Props extends NavigationProps {
   plant: Plant;
@@ -36,9 +36,9 @@ const PlantListItem: FunctionComponent<Props> = ({ plant, navigation }) => {
       }}
     >
       <View style={styles.plantItem}>
-        <FastImage
-          source={{ uri: plant.avatar }}
-          style={styles.plantItemImage}
+        <ImageWithIndicator
+          source={plant.avatar}
+          imageStyle={styles.plantItemImage}
         />
         <Text>{plant.name}</Text>
       </View>

--- a/src/components/shared/ImageWithIndicator.tsx
+++ b/src/components/shared/ImageWithIndicator.tsx
@@ -1,0 +1,35 @@
+import React, {useState, FunctionComponent} from "react";
+import {ActivityIndicator, StyleSheet, StyleProp, View, ViewStyle} from "react-native";
+
+import FastImage from "react-native-fast-image";
+
+interface Props {
+  source: string;
+  imageStyle: StyleProp<ViewStyle>;
+}
+
+const styles = StyleSheet.create({
+  indicatorStyle: {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+  },
+});
+
+const ImageWithIndicator: FunctionComponent<Props> = ({source, imageStyle}) => {
+  const [loading, setLoading] = useState(true);
+  return (
+    <View>
+      {loading && <ActivityIndicator size="large" style={styles.indicatorStyle} />}
+      <FastImage
+        source={{uri: source}}
+        style={imageStyle}
+        onLoadEnd={(): void => {
+          setLoading(false);
+        }}
+      />
+    </View>
+  );
+};
+
+export default ImageWithIndicator;

--- a/src/screens/PlantDetails.tsx
+++ b/src/screens/PlantDetails.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent, useState, useEffect } from "react";
 import { Dimensions, Text, View, StyleSheet, ScrollView } from "react-native";
-import FastImage from "react-native-fast-image";
 
 import CheckInList from "../components/plants/CheckInList";
 import { NavigationProps } from "../components/Router";
 import { fetchPlant } from "../api/Api";
 import { Plant } from "../api/Types";
+import ImageWithIndicator from "../components/shared/ImageWithIndicator";
 
 const windowWidth = Dimensions.get("window").width;
 const windowHeight = Dimensions.get("window").height;
@@ -62,7 +62,10 @@ const PlantDetails: FunctionComponent<NavigationProps> = ({ navigation }) => {
       <ScrollView style={styles.pageContainer}>
         <View style={styles.detailsContainer}>
           <Text style={styles.plantName}>{plant.name}</Text>
-          <FastImage source={{ uri: plant.avatar }} style={styles.plantImage} />
+          <ImageWithIndicator
+            source={plant.avatar}
+            imageStyle={styles.plantImage}
+          />
           <Text style={styles.checkInHeader}>
             Next check-in due: {plant.next_check_date}
           </Text>


### PR DESCRIPTION
WHY

Images leave blank white spaces while loading.

WHAT

This commit adds a new component that adds a loading state to images so
that a user knows an image is loading.

When the image is initially loading, the ActivityIndicator is shown in
the center of where the image should appear. Once the image is finished
loading, the ActivityIndicator is hidden from view.

This looks like it works well with FastImage's `onLoadEnd` prop. Once
the image is cached, the ActivityIndicator doesn't seem to appear on subsequent renders of an image.