### PR TITLE
Upload Plant Avatar

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,6 +133,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        missingDimensionStrategy 'react-native-camera', 'general'
     }
     splits {
         abi {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,7 +135,6 @@ android {
         versionName "1.0"
         missingDimensionStrategy 'react-native-camera', 'general'
         vectorDrawables.useSupportLibrary = true
-
     }
     splits {
         abi {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -134,6 +134,8 @@ android {
         versionCode 1
         versionName "1.0"
         missingDimensionStrategy 'react-native-camera', 'general'
+        vectorDrawables.useSupportLibrary = true
+
     }
     splits {
         abi {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
   package="com.plantifulmobile">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
       android:name=".MainApplication"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,5 +33,6 @@ allprojects {
         google()
         jcenter()
         maven { url 'https://jitpack.io' }
+        maven { url 'https://maven.google.com' }
     }
 }

--- a/ios/PlantifulMobile.xcodeproj/project.pbxproj
+++ b/ios/PlantifulMobile.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PlantifulMobile/Pods-PlantifulMobile-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/QBImagePickerController/QBImagePicker.bundle",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
@@ -455,9 +456,11 @@
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Octicons.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Zocial.ttf",
+				"${PODS_ROOT}/RSKImageCropper/RSKImageCropper/RSKImageCropperStrings.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AntDesign.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EvilIcons.ttf",
@@ -474,6 +477,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Octicons.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SimpleLineIcons.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Zocial.ttf",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RSKImageCropperStrings.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/PlantifulMobile/Info.plist
+++ b/ios/PlantifulMobile/Info.plist
@@ -58,5 +58,17 @@
 		<string>Octicons.ttf</string>
 		<string>Ionicons.ttf</string>
 	</array>
+  <key>NSCameraUsageDescription</key>
+  <string>
+    We need to access your camera to take photos of your plants.
+  </string>
+  <key>NSPhotoLibraryAddUsageDescription</key>
+  <string>
+    We need to access your photo library so you can upload photos.
+  </string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>
+    We need to access your photo library so you can upload photos.
+  </string>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,6 +34,8 @@ target 'PlantifulMobile' do
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+  pod 'QBImagePickerController', :path => '../node_modules/react-native-image-crop-picker/ios/QBImagePicker/QBImagePickerController.podspec'
+
 
   target 'PlantifulMobileTests' do
     inherit! :search_paths

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -191,6 +191,14 @@ PODS:
     - React-cxxreact (= 0.61.2)
     - React-jsi (= 0.61.2)
   - React-jsinspector (0.61.2)
+  - react-native-camera (3.15.1):
+    - React
+    - react-native-camera/RCT (= 3.15.1)
+    - react-native-camera/RN (= 3.15.1)
+  - react-native-camera/RCT (3.15.1):
+    - React
+  - react-native-camera/RN (3.15.1):
+    - React
   - React-RCTActionSheet (0.61.2):
     - React-Core/RCTActionSheetHeaders (= 0.61.2)
   - React-RCTAnimation (0.61.2):
@@ -265,6 +273,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
+  - react-native-camera (from `../node_modules/react-native-camera`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
@@ -320,6 +329,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
+  react-native-camera:
+    :path: "../node_modules/react-native-camera"
   React-RCTActionSheet:
     :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -372,6 +383,7 @@ SPEC CHECKSUMS:
   React-jsi: 32285a21b1b24c36060493ed3057a34677d58d09
   React-jsiexecutor: 8909917ff7d8f21a57e443a866fd8d4560e50c65
   React-jsinspector: 111d7d342b07a904c400592e02a2b958f1098b60
+  react-native-camera: 1ba3e7f2375a6b44ae09ce9be70268e0b225bc10
   React-RCTActionSheet: 89b037c0fb7d2671607cb645760164e7e0c013f6
   React-RCTAnimation: e3cefa93c38c004c318f7ec04b883eb14b8b8235
   React-RCTBlob: d26ac0e313fbf14e7203473fd593ccaaeee8329e

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -28,6 +28,7 @@ PODS:
   - libwebp/mux (1.0.3):
     - libwebp/demux
   - libwebp/webp (1.0.3)
+  - QBImagePickerController (3.4.0)
   - RCTRequired (0.61.2)
   - RCTTypeSafety (0.61.2):
     - FBLazyVector (= 0.61.2)
@@ -242,12 +243,18 @@ PODS:
     - SDWebImageWebPCoder (~> 0.2.3)
   - RNGestureHandler (1.5.3):
     - React
+  - RNImageCropPicker (0.27.0):
+    - QBImagePickerController
+    - React-Core
+    - React-RCTImage
+    - RSKImageCropper
   - RNReanimated (1.7.0):
     - React
   - RNScreens (1.0.0-alpha.23):
     - React
   - RNVectorIcons (6.6.0):
     - React
+  - RSKImageCropper (2.2.3)
   - SDWebImage (5.4.1):
     - SDWebImage/Core (= 5.4.1)
   - SDWebImage/Core (5.4.1)
@@ -262,6 +269,7 @@ DEPENDENCIES:
   - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - QBImagePickerController (from `../node_modules/react-native-image-crop-picker/ios/QBImagePicker/QBImagePickerController.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
   - React (from `../node_modules/react-native/`)
@@ -288,6 +296,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - RNFastImage (from `../node_modules/react-native-fast-image`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
@@ -297,6 +306,7 @@ SPEC REPOS:
   trunk:
     - boost-for-react-native
     - libwebp
+    - RSKImageCropper
     - SDWebImage
     - SDWebImageWebPCoder
 
@@ -311,6 +321,8 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/Folly.podspec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
+  QBImagePickerController:
+    :path: "../node_modules/react-native-image-crop-picker/ios/QBImagePicker/QBImagePickerController.podspec"
   RCTRequired:
     :path: "../node_modules/react-native/Libraries/RCTRequired"
   RCTTypeSafety:
@@ -357,6 +369,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-fast-image"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNImageCropPicker:
+    :path: "../node_modules/react-native-image-crop-picker"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -374,6 +388,7 @@ SPEC CHECKSUMS:
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   libwebp: 057912d6d0abfb6357d8bb05c0ea470301f5d61e
+  QBImagePickerController: d54cf93db6decf26baf6ed3472f336ef35cae022
   RCTRequired: c639d59ed389cfb1f1203f65c2ea946d8ec586e2
   RCTTypeSafety: dc23fb655d6c77667c78e327bf661bc11e3b8aec
   React: 7e586e5d7bec12b91c1a096826b0fc9ab1da7865
@@ -397,13 +412,15 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 44395cb9c7c1523104c2b499eb426ef7aff82bca
   RNFastImage: 9b0c22643872bb7494c8d87bbbb66cc4c0d9e7a2
   RNGestureHandler: 02905abe54e1f6e59c081a10b4bd689721e17aa6
+  RNImageCropPicker: fcdbbbef2f0ea869c6d9ce39b8e4fd67e94009f4
   RNReanimated: 031fe8d9ea93c2bd689a40f05320ef9d96f74d7f
   RNScreens: f28b48b8345f2f5f39ed6195518291515032a788
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
+  RSKImageCropper: a446db0e8444a036b34f3c43db01b2373baa4b2a
   SDWebImage: 29c340dbdcef342bb13125553f4e19ce056b07a7
   SDWebImageWebPCoder: 947093edd1349d820c40afbd9f42acb6cdecd987
   Yoga: 14927e37bd25376d216b150ab2a561773d57911f
 
-PODFILE CHECKSUM: 9cf3ab5a09dd6422e362696df7c4d960d92cbad9
+PODFILE CHECKSUM: 97d0aabe13d09921b30c0b5c4e9ac1cdb79552ff
 
 COCOAPODS: 1.8.4

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lodash": "^4.17.15",
     "react": "16.9.0",
     "react-native": "0.61.2",
+    "react-native-camera": "^3.15.1",
     "react-native-fast-image": "^7.0.2",
     "react-native-gesture-handler": "^1.4.1",
     "react-native-numeric-input": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-native-camera": "^3.15.1",
     "react-native-fast-image": "^7.0.2",
     "react-native-gesture-handler": "^1.4.1",
+    "react-native-image-crop-picker": "^0.27.0",
     "react-native-numeric-input": "^1.8.3",
     "react-native-reanimated": "^1.3.0",
     "react-native-screens": "^1.0.0-alpha.23",

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -152,7 +152,7 @@ const createCheckIn = async (
 
 const uploadAvatar = async (
   plantId: number,
-  photoData: string,
+  photoData: string | null,
 ): Promise<Plant> => {
   const authToken = await getAuthenticationToken();
 

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -6,7 +6,7 @@ import { Garden, User, Plant, CheckIn } from "./Types";
 
 const baseApiUrl =
   Platform.OS == "android"
-    ? "http://10.0.2.2:3000/api"
+    ? "http://192.168.1.142:3000/api"
     : "http://localhost:3000/api";
 
 const defaultHeaders = {
@@ -150,6 +150,33 @@ const createCheckIn = async (
     .catch((error: Error): void => console.error(error.message));
 };
 
+const uploadAvatar = async (
+  plantId: number,
+  photoData: string,
+): Promise<Plant> => {
+  const authToken = await getAuthenticationToken();
+
+  return fetch(`${baseApiUrl}/plants/${plantId}/avatar`, {
+    method: "POST",
+    headers: {
+      ...defaultHeaders,
+      Authorization: `Bearer ${authToken}`,
+    },
+    body: JSON.stringify({
+      plant: { avatar: photoData },
+    }),
+  }).then((response: Response) => {
+    if (response.ok) {
+      return response.json();
+    } else if (response.status == 401) {
+      AsyncStorage.removeItem("authentication_token");
+      return undefined;
+    } else {
+      throw Error(response.statusText);
+    }
+  });
+};
+
 const signIn = async (email: string, password: string): Promise<User> => {
   return fetch(`${baseApiUrl}/sessions`, {
     method: "POST",
@@ -219,4 +246,5 @@ export {
   signIn,
   signOut,
   signUp,
+  uploadAvatar,
 };

--- a/src/components/Router.ts
+++ b/src/components/Router.ts
@@ -15,6 +15,7 @@ import PlantList from "../screens/PlantList";
 import PlantForm from "../screens/PlantForm";
 import PlantDetails from "../screens/PlantDetails";
 import PlantCheckIn from "../screens/PlantCheckIn";
+import Camera from "../screens/Camera";
 
 const headerStyle = {
   marginTop: Platform.OS === "android" ? StatusBar.currentHeight : 0,
@@ -46,6 +47,7 @@ const PlantsNavigationStack = createStackNavigator({
   PlantForm,
   PlantDetails,
   PlantCheckIn,
+  Camera,
 });
 
 const SignedIn = createBottomTabNavigator({

--- a/src/components/shared/ImageWithIndicator.tsx
+++ b/src/components/shared/ImageWithIndicator.tsx
@@ -27,7 +27,6 @@ const ImageWithIndicator: FunctionComponent<Props> = ({
   imageStyle,
 }) => {
   const [loading, setLoading] = useState(true);
-  console.log(source);
   return (
     <View>
       {loading && (

--- a/src/screens/Camera.tsx
+++ b/src/screens/Camera.tsx
@@ -1,0 +1,77 @@
+import React, { FunctionComponent, ReactElement } from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { RNCamera } from "react-native-camera";
+import { NavigationProps } from "../components/Router";
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: "column",
+    backgroundColor: "black",
+  },
+  preview: {
+    flex: 1,
+    justifyContent: "flex-end",
+    alignItems: "center",
+  },
+  capture: {
+    flex: 0,
+    backgroundColor: "#fff",
+    borderRadius: 5,
+    padding: 15,
+    paddingHorizontal: 20,
+    alignSelf: "center",
+    margin: 20,
+  },
+});
+
+const takePicture = async (
+  camera: RNCamera,
+  onPictureTaken: (data: string | undefined) => any,
+): Promise<void> => {
+  const options = { quality: 0.5, base64: true };
+  const data = await camera.takePictureAsync(options);
+  const rawBase64 = data.base64;
+  const base64Image = `data:image/jpeg;base64,${rawBase64}`;
+
+  onPictureTaken(base64Image);
+};
+
+const Camera: FunctionComponent<NavigationProps> = ({ navigation }) => {
+  const onPictureTaken = navigation.getParam("onPictureTaken", () => {
+    console.error("must navigate with onPictureTaken function param");
+  });
+  return (
+    <View style={styles.container}>
+      <RNCamera style={styles.preview}>
+        {({ camera, status }): ReactElement => {
+          if (status !== "READY") {
+            return <Text>Loading...</Text>;
+          } else {
+            return (
+              <View
+                style={{
+                  flex: 0,
+                  flexDirection: "row",
+                  justifyContent: "center",
+                }}
+              >
+                <TouchableOpacity
+                  onPress={(): void => {
+                    takePicture(camera, onPictureTaken);
+                    navigation.goBack();
+                  }}
+                  style={styles.capture}
+                >
+                  <Text style={{ fontSize: 14 }}> SNAP </Text>
+                </TouchableOpacity>
+              </View>
+            );
+          }
+        }}
+      </RNCamera>
+    </View>
+  );
+};
+
+export default Camera;

--- a/src/screens/Camera.tsx
+++ b/src/screens/Camera.tsx
@@ -2,10 +2,7 @@ import React, { FunctionComponent, ReactElement } from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { RNCamera } from "react-native-camera";
 import { NavigationProps } from "../components/Router";
-
-enum PhotoOrientation {
-  Portrait = "portrait",
-}
+import ImagePicker from "react-native-image-crop-picker";
 
 const styles = StyleSheet.create({
   container: {
@@ -31,20 +28,24 @@ const styles = StyleSheet.create({
 
 const takePicture = async (
   camera: RNCamera,
-  onPictureTaken: (data: string | undefined) => any,
+  onPictureTaken: (data: string | null) => any,
 ): Promise<void> => {
   const options = {
-    base64: true,
-    doNotSave: true,
     fixOrientation: true,
     forceUpOrientation: true,
-    quality: 0.6,
   };
   const data = await camera.takePictureAsync(options);
-  const rawBase64 = data.base64;
-  const base64Image = `data:image/jpeg;base64,${rawBase64}`;
+  const uri = data.uri;
 
-  onPictureTaken(base64Image);
+  ImagePicker.openCropper({
+    path: uri,
+    width: 400,
+    height: 400,
+    includeBase64: true,
+  }).then(image => {
+    const base64Image = `data:image/jpeg;base64,${image.data}`;
+    onPictureTaken(base64Image);
+  });
 };
 
 const Camera: FunctionComponent<NavigationProps> = ({ navigation }) => {
@@ -68,8 +69,9 @@ const Camera: FunctionComponent<NavigationProps> = ({ navigation }) => {
               >
                 <TouchableOpacity
                   onPress={(): void => {
-                    takePicture(camera, onPictureTaken);
-                    navigation.goBack();
+                    takePicture(camera, onPictureTaken).then(() => {
+                      navigation.goBack();
+                    });
                   }}
                   style={styles.capture}
                 >

--- a/src/screens/Camera.tsx
+++ b/src/screens/Camera.tsx
@@ -3,6 +3,10 @@ import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { RNCamera } from "react-native-camera";
 import { NavigationProps } from "../components/Router";
 
+enum PhotoOrientation {
+  Portrait = "portrait",
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -29,7 +33,13 @@ const takePicture = async (
   camera: RNCamera,
   onPictureTaken: (data: string | undefined) => any,
 ): Promise<void> => {
-  const options = { quality: 0.5, base64: true };
+  const options = {
+    base64: true,
+    doNotSave: true,
+    fixOrientation: true,
+    forceUpOrientation: true,
+    quality: 0.6,
+  };
   const data = await camera.takePictureAsync(options);
   const rawBase64 = data.base64;
   const base64Image = `data:image/jpeg;base64,${rawBase64}`;
@@ -46,7 +56,7 @@ const Camera: FunctionComponent<NavigationProps> = ({ navigation }) => {
       <RNCamera style={styles.preview}>
         {({ camera, status }): ReactElement => {
           if (status !== "READY") {
-            return <Text>Loading...</Text>;
+            return <Text>Loading Camera...</Text>;
           } else {
             return (
               <View

--- a/src/screens/PlantDetails.tsx
+++ b/src/screens/PlantDetails.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent, useState, useEffect } from "react";
-import { Dimensions, Text, View, StyleSheet, ScrollView } from "react-native";
+import {Dimensions, Text, TouchableOpacity, View, StyleSheet, ScrollView} from "react-native";
 
 import CheckInList from "../components/plants/CheckInList";
 import { NavigationProps } from "../components/Router";
-import { fetchPlant } from "../api/Api";
+import { fetchPlant, uploadAvatar } from "../api/Api";
 import { Plant } from "../api/Types";
 import ImageWithIndicator from "../components/shared/ImageWithIndicator";
 import ActionButton from "../components/ActionButton";
@@ -36,6 +36,7 @@ const styles = StyleSheet.create({
 const PlantDetails: FunctionComponent<NavigationProps> = ({ navigation }) => {
   const [plant, setPlant] = useState<Plant>();
   const [loading, setLoading] = useState(true);
+  const [avatarPhotoData, setAvatarPhotoData] = useState();
   const plantId = navigation.getParam("id", null);
   const plantName = plant?.name;
 
@@ -55,6 +56,13 @@ const PlantDetails: FunctionComponent<NavigationProps> = ({ navigation }) => {
     };
   }, []);
 
+  useEffect(() => {
+    if (avatarPhotoData) {
+      console.log("uploading photo");
+      uploadAvatar(plantId, avatarPhotoData);
+    }
+  }, [avatarPhotoData]);
+
   if (loading) {
     return <Text>Loading...</Text>;
   }
@@ -70,10 +78,17 @@ const PlantDetails: FunctionComponent<NavigationProps> = ({ navigation }) => {
         <ScrollView style={styles.pageContainer}>
           <View style={styles.detailsContainer}>
             <Text style={styles.plantName}>{plant.name}</Text>
-            <ImageWithIndicator
-              source={plant.avatar}
-              imageStyle={styles.plantImage}
-            />
+            <TouchableOpacity onPress={(): void => {
+              navigation.navigate(
+                "Camera",
+                {onPictureTaken: setAvatarPhotoData},
+              );
+            }}>
+              <ImageWithIndicator
+                source={avatarPhotoData || plant.avatar}
+                imageStyle={styles.plantImage}
+              />
+            </TouchableOpacity>
             <Text style={styles.checkInHeader}>
               Next check-in due: {plant.next_check_date}
             </Text>

--- a/src/screens/PlantDetails.tsx
+++ b/src/screens/PlantDetails.tsx
@@ -58,7 +58,6 @@ const PlantDetails: FunctionComponent<NavigationProps> = ({ navigation }) => {
 
   useEffect(() => {
     if (avatarPhotoData) {
-      console.log("uploading photo");
       uploadAvatar(plantId, avatarPhotoData);
     }
   }, [avatarPhotoData]);

--- a/src/screens/PlantDetails.tsx
+++ b/src/screens/PlantDetails.tsx
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 const PlantDetails: FunctionComponent<NavigationProps> = ({ navigation }) => {
   const [plant, setPlant] = useState<Plant>();
   const [loading, setLoading] = useState(true);
-  const [avatarPhotoData, setAvatarPhotoData] = useState();
+  const [avatarPhotoData, setAvatarPhotoData] = useState(null);
   const plantId = navigation.getParam("id", null);
   const plantName = plant?.name;
 
@@ -57,7 +57,7 @@ const PlantDetails: FunctionComponent<NavigationProps> = ({ navigation }) => {
   }, []);
 
   useEffect(() => {
-    if (avatarPhotoData) {
+    if (avatarPhotoData !== null) {
       uploadAvatar(plantId, avatarPhotoData);
     }
   }, [avatarPhotoData]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5071,6 +5071,13 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-native-camera@^3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-3.15.1.tgz#8e4eb67cb6687b5250f849b348f0d19a01649105"
+  integrity sha512-xj1sljzFq8HVX22d2T945dsJdK/KFb3jaXUHEYGwMp/zz0ypIs3mY3NezdpyYpS1ioKKzdIcLrxz2VKzDCXaCg==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-native-fast-image@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-7.0.2.tgz#e06b21f42f4a9786eaa86f3db35d919070fb8403"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5093,6 +5093,11 @@ react-native-gesture-handler@^1.4.1:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-image-crop-picker@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/react-native-image-crop-picker/-/react-native-image-crop-picker-0.27.0.tgz#f4684e77e6b25bb6d2cb5e37cfad130b4ed23e90"
+  integrity sha512-QR9d3FQVYO1vIUOHt5kozyyTUzHV71wGsLKbzqINjF4kKW9++lHHt7DgEkXBuOHWOZ26LHyQHXV6GdQRPA2EkQ==
+
 react-native-numeric-input@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/react-native-numeric-input/-/react-native-numeric-input-1.8.3.tgz#e869aa1b60d0c38b92e84e44bb28944f48b4ccd3"


### PR DESCRIPTION
This commit adds the ability to upload a new avatar for plants from the PlantDetails screen. Two new libraries were added to handle image capture and cropping, `react-native-camera` and `react-native-image-cropper`, respectively.

The avatar image component is now wrapped with a TouchableOpacity that navigates the user to the newly added `Camera` screen. The user is present with a camera viewfinder and once they take a picture they are presented with the cropper. Once the image is cropped, the upload of the new avatar is started and the previous image is replaced with newly cropped one.